### PR TITLE
build: bump `java.version` to 17 to fix jitpack build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<name>One In The Chamber</name>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 


### PR DESCRIPTION
This PR bump the `java.version` in `pom.xml` to 17 to fix jitpack build failure. Tested on [jitpack](https://jitpack.io/#HappyAreaBean/OITC).